### PR TITLE
Replace OWASP Dependency-Check with Snyk for Vulnerability Scanning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,11 +166,10 @@ stages:
               organization: $(snykAbzuOrganizationId)
               serviceConnectionEndpoint: Snyk
               codeSeverityThreshold: low
-              testType: IaC
+              testType: iac
               monitorwhen: never
               severityThreshold: low
               workingDirectory: '$(Build.SourcesDirectory)/Deployment'
-
 
       - job: UnitTestsAndCodeCoverage
         workspace:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: SnykCheck_Build_Test_Publish
+  - stage: Snyk Check ,Build, Test and Publish
     displayName: "Snyk Checks"
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
               additionalArguments: --all-projects
 
           - task: UkhoSnykScanTask@0
-            displayName: Snyk SCA scan
+            displayName: Snyk Iac scan
             condition: succeededOrFailed()
             inputs:
               failOnIssues: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,57 +105,57 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: PERFORM_DEPENDENCYCHECK_DOTNETBUILD_DOTNETTEST_AND_PUBLISH
-    displayName: "Build (DependencyChecker, Dotnet Build & Restore , Dotnet Test and Publish Artifact )"
+  - stage: VulnerabilityChecks
+    displayName: "Snyk Checks"
     dependsOn: []
     jobs:
-      - job: Dependencychecker
-        pool: NautilusBuild
-        condition: eq('${{ parameters.DisableDependencyCheck }}', false)      
-        workspace:
-          clean: all
-        displayName: "Dependencychecker"
+      - job: Snyk
+        displayName: Run Snyk security scans
+        pool: $(WindowsPool)
         steps:
           - task: UseDotNet@2
-            displayName: 'Use .NET sdk'
+            displayName: Use .NET SDK $(SdkVersion)
             inputs:
               packageType: sdk
-              useGlobalJson: true
-              workingDirectory: '$(Build.SourcesDirectory)\src'
+              version: $(SdkVersion)
 
           - task: DotNetCoreCLI@2
-            displayName: ".Net Core - NuGet restore non test projects only"
+            displayName: .NET - NuGet restore
             inputs:
-              command: "restore"
+              command: restore
               projects: |
                 **/*.csproj
-                !**/*Tests.csproj
               feedsToUse: config
               noCache: true
               nugetConfigPath: '$(Build.SourcesDirectory)\BuildNuget.config'
-              workingDirectory: '$(Build.SourcesDirectory)\src'
-              packagesDirectory: '$(Build.SourcesDirectory)\src\packagesForAPI'
+              workingDirectory: '$(Build.SourcesDirectory)'
 
-          - task: CmdLine@1
-            displayName: "Run OWASP Dependency Checker"
+          - task: UkhoSnykScanTask@0
+            displayName: Snyk SAST scan
+            condition: succeededOrFailed()
             inputs:
-              filename: 'dependency-check.bat'
-              arguments: '--project "s-100-permit-service - $(Build.SourceBranchName)" --scan "$(Build.SourcesDirectory)\src" --out "$(Build.ArtifactStagingDirectory)\DCReport" --suppression $(Build.SourcesDirectory)\NVDSuppressions.xml --noupdate'
+              failOnIssues: true
+              failOnThreshold: high
+              organization: $(snykAbzuOrganizationId)
+              serviceConnectionEndpoint: Snyk
+              codeSeverityThreshold: low
+              testType: code
+              monitorwhen: never
 
-          - task: PublishBuildArtifacts@1
-            displayName: "Publish Artifact: OWASP Dependency Checker Report"
+          - task: UkhoSnykScanTask@0
+            displayName: Snyk SCA scan
+            condition: succeededOrFailed()
             inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)\DCReport'
-              ArtifactName: "OWASP Dependency Checker Report"
+              failOnIssues: true
+              failOnThreshold: high
+              organization: $(snykAbzuOrganizationId)
+              serviceConnectionEndpoint: Snyk
+              codeSeverityThreshold: low
+              testType: app
+              monitorwhen: never
+              severityThreshold: low
+              additionalArguments: --all-projects
 
-          - task: PowerShell@1
-            displayName: "Fail Build if Dependency Check Finds Any Vulnerabilities"
-            inputs:
-              scriptType: inlineScript
-              arguments: '-ReportLocation $(Build.ArtifactStagingDirectory)\DCReport\*'
-              inlineScript: |
-                param($ReportLocation)
-                Invoke-VulnerabilityCheck -ReportLocation $ReportLocation
 
       - job: UnitTestsAndCodeCoverage
         workspace:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,8 @@ variables:
     value: "90"
   - name: DeploymentPoolPE
     value: "Private Link Deployments (ENG)"
+  - name: snykAbzuOrganizationId
+    value: "aeb7543b-8394-457c-8334-a31493d8910d"
 
 stages:
 
@@ -116,8 +118,7 @@ stages:
           - task: UseDotNet@2
             displayName: Use .NET SDK $(SdkVersion)
             inputs:
-              packageType: sdk
-              version: $(SdkVersion)
+              packageType: sdk             
 
           - task: DotNetCoreCLI@2
             displayName: .NET - NuGet restore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,7 @@ stages:
               testType: IaC
               monitorwhen: never
               severityThreshold: low
-              additionalArguments: --all-projects
+              workingDirectory: '$(Build.SourcesDirectory)/Deployment'
 
 
       - job: UnitTestsAndCodeCoverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,6 +157,20 @@ stages:
               severityThreshold: low
               additionalArguments: --all-projects
 
+          - task: UkhoSnykScanTask@0
+            displayName: Snyk SCA scan
+            condition: succeededOrFailed()
+            inputs:
+              failOnIssues: true
+              failOnThreshold: high
+              organization: $(snykAbzuOrganizationId)
+              serviceConnectionEndpoint: Snyk
+              codeSeverityThreshold: low
+              testType: IaC
+              monitorwhen: never
+              severityThreshold: low
+              additionalArguments: --all-projects
+
 
       - job: UnitTestsAndCodeCoverage
         workspace:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: Snyk Check ,Build, Test and Publish
+  - stage: SnykCheck_Build_Test_Publish
     displayName: "Snyk Checks"
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: VulnerabilityChecks
+  - stage: Snyk Check ,Build, Test and Publish
     displayName: "Snyk Checks"
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,8 +107,8 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: VulnerabilityChecks
-    displayName: "Snyk Checks"
+  - stage: SnykCheck_Build_Test_Publish
+    displayName: "Snyk Check ,Build, Test and Publish"
     dependsOn: []
     jobs:
       - job: Snyk

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
               reportPattern: '$(Build.SourcesDirectory)/tests/UKHO.S100PermitService.Common.UnitTests/**/mutation-report.html'
               reportDisplayName: 'Permit Service Common Mutation Report'
 
-  - stage: Snyk Check ,Build, Test and Publish
+  - stage: VulnerabilityChecks
     displayName: "Snyk Checks"
     dependsOn: []
     jobs:


### PR DESCRIPTION
This PR replaces the existing OWASP Dependency-Check tool with Snyk for open-source vulnerability scanning and dependency analysis.